### PR TITLE
Api registrar artista

### DIFF
--- a/API/api.py
+++ b/API/api.py
@@ -8,6 +8,8 @@ from utils.queries.Genre.get_generos import *
 from utils.queries.Cluster.get_clusters import *
 from utils.queries.Artist.crear_artista import *
 from utils.queries.Artist.guardar_album import *
+from utils.queries.Artist.guardar_miembro import *
+from utils.queries.Artist.guardar_miembro import *
 
 app = Flask(__name__)
 
@@ -61,6 +63,7 @@ def obtener_generos():
 def obtener_clusters():
     return getClusters()
 
+
 @app.route('/api/crear_artista_completo', methods=['POST'])
 def crear_artista_completo():
     data = request.get_json()
@@ -74,18 +77,17 @@ def crear_artista_completo():
         # Paso 2: Guardar artista → obtener ID
         error_response, artist_id = guardarArtistaDB(artista_data)
         if error_response:
-            return error_response, 400  # O el código de estado apropiado
+            return error_response, 400  # Ya incluye status_code si lo ajustaste
 
-        # Paso 3: Procesar álbumes
+        # Paso 3: Guardar álbumes
         album_ids, error_response = guardar_albumes(data, artist_id)
         if error_response:
-            return error_response, 400
+            return error_response, 400  # Igual, se espera que incluya status code
 
-        # Paso 4: Si es banda, guardar miembros
-        if data.get('is_band', False):
-            miembros = data.get('members', [])
-            for miembro in miembros:
-                guardarMiembroDB(miembro, artist_id)
+        # Paso 4: Guardar miembros si es banda
+        error_response, status_code = guardarMiembro(data, artist_id)
+        if error_response:
+            return error_response, status_code
 
         return jsonify({
             "mensaje": "Artista, álbumes y miembros registrados exitosamente.",

--- a/API/utils/queries/Artist/crear_artista.py
+++ b/API/utils/queries/Artist/crear_artista.py
@@ -1,0 +1,128 @@
+import traceback
+from utils.database.database import db
+from flask import jsonify
+from sqlalchemy.exc import IntegrityError
+from utils.models.artist_models import *
+from sqlalchemy import func, text
+from sqlalchemy import cast
+from sqlalchemy.dialects.postgresql import VARCHAR, INTEGER, BOOLEAN
+from sqlalchemy import Numeric as DECIMAL
+
+def crearArtistaData(data):
+    try:
+        # Validaciones básicas obligatorias
+        if not data.get('nombre') or len(data['nombre']) < 3:
+            return None, jsonify({"error": "El nombre es obligatorio y debe tener al menos 3 caracteres"}), 400
+
+        if not data.get('pais'):
+            return None, jsonify({"error": "El país de origen es obligatorio"}), 400
+
+        if not data.get('año_desde'):
+            return None, jsonify({"error": "El año de inicio (año_desde) es obligatorio"}), 400
+
+        # Procesar años y estado de actividad
+        try:
+            start_year = int(data['año_desde'])
+        except ValueError:
+            return None, jsonify({"error": "El año de inicio debe ser un número válido"}), 400
+
+        end_year_raw = data.get('año_hasta', None) 
+
+        if end_year_raw and isinstance(end_year_raw, str) and end_year_raw.strip().lower() == "presente":
+            end_year = None
+            is_present = True
+        else:
+            is_present = False
+            try:
+                end_year = int(end_year_raw) if end_year_raw else None
+            except ValueError:
+                return None, jsonify({"error": "El año de fin debe ser un número válido o 'presente'"}), 400
+
+        # Géneros y subgéneros
+        genre_ids = data.get('genre_ids', [])
+        subgenre_ids = data.get('subgenre_ids', [])
+
+        if not isinstance(genre_ids, list) or not all(isinstance(g, str) for g in genre_ids):
+            return None, jsonify({"error": "genre_ids debe ser una lista de strings"}), 400
+
+        if not isinstance(subgenre_ids, list) or not all(isinstance(s, str) for s in subgenre_ids):
+            return None, jsonify({"error": "subgenre_ids debe ser una lista de strings"}), 400
+
+        # Datos opcionales
+        biography = data.get('biografia', '')
+        cover_image_path = data.get('cover_image_path', None)
+
+        artista = {
+            "name": data['nombre'],
+            "biography": biography,
+            "country": data['pais'],
+            "cover_image_path": cover_image_path,
+            "start_year": start_year,
+            "end_year": end_year,
+            "is_present": is_present,
+            "genre_ids": genre_ids,
+            "subgenre_ids": subgenre_ids
+        }
+
+        return artista, None, None
+
+    except Exception as e:
+        return None, jsonify({
+            "error": "Error procesando datos del artista",
+            "detalle": str(e),
+            "trace": traceback.format_exc()
+        }), 500
+
+def guardarArtistaDB(artista):
+    try:
+        if artista is None:
+            raise ValueError("No se pudo crear el objeto 'artista'. Verifique los datos de entrada.")
+
+        query = text("""
+            SELECT register_artist(
+                :p_name,
+                :p_biography,
+                :p_country,
+                :p_cover_image_path,
+                :p_date_start,
+                :p_date_end,
+                :p_is_present,
+                :p_genre_ids,
+                :p_subgenre_ids
+            )
+        """)
+
+        result = db.session.execute(query, {
+            'p_name': artista['name'],
+            'p_biography': artista['biography'],
+            'p_country': artista['country'],
+            'p_cover_image_path': artista['cover_image_path'],
+            'p_date_start': artista['start_year'],
+            'p_date_end': artista['end_year'],
+            'p_is_present': artista['is_present'],
+            'p_genre_ids': artista['genre_ids'],
+            'p_subgenre_ids': artista['subgenre_ids']
+        })
+
+        artist_id = result.scalar()
+        db.session.commit()
+
+        # Devuelve None para error_response y el artist_id
+        return None, artist_id
+
+    except IntegrityError as e:
+        db.session.rollback()
+        error_response = jsonify({
+            "error": "Restricción de integridad violada",
+            "detalle": str(e)
+        })
+        return error_response, None
+
+    except Exception as e:
+        db.session.rollback()
+        print("Error en servidor:", traceback.format_exc())
+        error_response = jsonify({
+            "error": "Error inesperado al registrar el artista",
+            "detalle": str(e)
+        })
+        return error_response, None

--- a/API/utils/queries/Artist/get_artists.py
+++ b/API/utils/queries/Artist/get_artists.py
@@ -1,7 +1,7 @@
 from flask import jsonify
 from sqlalchemy.exc import IntegrityError
 # Assuming you have an Artist model defined in your models.py
-from API.utils.models.genre_models import Artist
+from utils.models.genre_models import Artist
 
 def getArtists():
     try:

--- a/API/utils/queries/Artist/guardar_album.py
+++ b/API/utils/queries/Artist/guardar_album.py
@@ -1,0 +1,85 @@
+import traceback
+from flask import jsonify
+from sqlalchemy.exc import IntegrityError
+from utils.database.database import db
+from sqlalchemy import text
+
+
+
+def _guardar_album_individual(album_data, artist_id):
+    """Función interna para guardar un solo álbum"""
+    try:
+        # Validaciones básicas
+        if not artist_id:
+            return None, jsonify({"error": "Artist ID inválido"}), 400
+
+        if not album_data.get('titulo'):
+            return None, jsonify({"error": "El título del álbum es obligatorio"}), 400
+
+        # Procesar fecha (convertir año a fecha completa)
+        release_year = album_data.get('año')
+        try:
+            release_date = f"{int(release_year)}-01-01" if release_year else None
+        except ValueError:
+            return None, jsonify({"error": "Año de lanzamiento inválido"}), 400
+
+        # Ejecutar función PostgreSQL con parámetros exactos
+        query = text("""
+            SELECT add_album(
+                :p_artist_id,
+                :p_title,
+                CAST(:p_release_date AS DATE),
+                :p_cover_image_path,
+                :p_duration_seconds
+            )
+        """)
+
+        result = db.session.execute(query, {
+            'p_artist_id': artist_id,
+            'p_title': album_data['titulo'],
+            'p_release_date': release_date,
+            'p_cover_image_path': album_data.get('cover_image_path'),
+            'p_duration_seconds': album_data.get('duration_seconds', 0)
+        })
+
+        album_id = result.scalar()
+        return album_id, None
+
+    except IntegrityError as e:
+        db.session.rollback()
+        return None, jsonify({
+            "error": "Error de integridad al guardar el álbum",
+            "detalle": str(e.orig) if hasattr(e, 'orig') else str(e)
+        }), 409
+
+    except Exception as e:
+        db.session.rollback()
+        return None, jsonify({
+            "error": "Error inesperado al guardar el álbum",
+            "detalle": str(e),
+            "trace": traceback.format_exc()
+        }), 500
+
+def guardar_albumes(data, artist_id):
+    """
+    Maneja el array completo de álbumes
+    Args:
+        albumes_data (list): Lista de diccionarios con datos de álbumes
+        artist_id (str): ID del artista padre
+    Returns:
+        tuple: (lista de IDs, None) si éxito, (None, error_response) si falla
+    """
+
+    albumes_data = data.get('albumes', [])
+    if not albumes_data:
+        return [], None  # Caso sin álbumes
+
+    album_ids = []
+    for album in albumes_data:
+        album_id, error = _guardar_album_individual(album, artist_id)
+        if error:
+            return None, error
+        album_ids.append(album_id)
+
+    db.session.commit()
+    return album_ids, None

--- a/API/utils/queries/Artist/guardar_album.py
+++ b/API/utils/queries/Artist/guardar_album.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 
 
 
-def _guardar_album_individual(album_data, artist_id):
+def guardar_album_individual(album_data, artist_id):
     """Función interna para guardar un solo álbum"""
     try:
         # Validaciones básicas
@@ -76,7 +76,7 @@ def guardar_albumes(data, artist_id):
 
     album_ids = []
     for album in albumes_data:
-        album_id, error = _guardar_album_individual(album, artist_id)
+        album_id, error = guardar_album_individual(album, artist_id)
         if error:
             return None, error
         album_ids.append(album_id)

--- a/API/utils/queries/Artist/guardar_miembro.py
+++ b/API/utils/queries/Artist/guardar_miembro.py
@@ -1,0 +1,104 @@
+import traceback
+from flask import jsonify
+from sqlalchemy.exc import IntegrityError
+from utils.database.database import db
+from sqlalchemy import text
+
+
+def guardar_miembro_individual(miembro_data, artist_id):
+    try:
+        if not artist_id:
+            return jsonify({"error": "Artist ID inválido"}), 400
+
+        if not miembro_data.get('nombre'):
+            return jsonify({"error": "El nombre del miembro es obligatorio"}), 400
+
+        if not miembro_data.get('instrumento'):
+            return jsonify({"error": "El instrumento del miembro es obligatorio"}), 400
+
+        # Convertir años a cadenas para coincidir con la función SQL (espera VARCHAR)
+        try:
+            start_period = str(int(miembro_data['desde']))
+        except ValueError:
+            return jsonify({"error": "El año de inicio debe ser un número válido"}), 400
+
+        end_period_raw = miembro_data.get('hasta', None)
+        is_current = bool(miembro_data.get('is_current', False))
+
+        if isinstance(end_period_raw, str) and end_period_raw.strip().lower() == "presente":
+            end_period = None
+            is_current = True
+        elif end_period_raw is not None:
+            try:
+                end_period = str(int(end_period_raw))
+            except ValueError:
+                return jsonify({"error": "El año de fin debe ser un número válido o 'presente'"}), 400
+        else:
+            end_period = None
+
+        # Ejecutar función PostgreSQL con parámetros exactos
+        query = text("""
+            SELECT add_band_member(
+                :p_artist_id,
+                :p_full_name,
+                :p_instrument,
+                :p_start_period,
+                :p_end_period,
+                :p_is_current
+            )
+        """)
+
+        result = db.session.execute(query, {
+            'p_artist_id': artist_id,
+            'p_full_name': miembro_data['nombre'],
+            'p_instrument': miembro_data['instrumento'],
+            'p_start_period': start_period,
+            'p_end_period': end_period,
+            'p_is_current': is_current,
+        })
+
+        return None
+
+    except IntegrityError as e:
+        db.session.rollback()
+        return jsonify({
+            "error": "Error de integridad al guardar el miembro",
+            "detalle": str(e.orig) if hasattr(e, 'orig') else str(e)
+        }), 409
+
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({
+            "error": "Error inesperado al guardar el miembro",
+            "detalle": str(e),
+            "trace": traceback.format_exc()
+        }), 500
+
+
+
+def guardarMiembro(data, artist_id):
+    try:
+        if data.get('is_band') is False:
+            return None, None
+
+        miembros_data = data.get('miembros', [])
+        if not miembros_data:
+            return None, None  # Caso sin miembros
+
+        for miembro in miembros_data:
+            error_response = guardar_miembro_individual(miembro, artist_id)
+            if error_response:
+                return error_response  # Esta ya es una tupla (jsonify, status)
+
+        db.session.commit()
+        return None, None
+
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({
+            "error": "Error al procesar miembros",
+            "detalle": str(e)
+        }), 500
+
+    
+

--- a/API/utils/queries/Cluster/crear_cluster_genero.py
+++ b/API/utils/queries/Cluster/crear_cluster_genero.py
@@ -2,7 +2,7 @@ import uuid
 from utils.database.database import db
 from flask import jsonify
 from sqlalchemy.exc import IntegrityError
-from API.utils.models.genre_models import Cluster
+from utils.models.genre_models import Cluster
 from sqlalchemy import func, text
 from sqlalchemy import cast
 from sqlalchemy.dialects.postgresql import VARCHAR, INTEGER, BOOLEAN

--- a/API/utils/queries/Cluster/get_clusters.py
+++ b/API/utils/queries/Cluster/get_clusters.py
@@ -1,6 +1,6 @@
 from flask import jsonify
 from sqlalchemy.exc import IntegrityError
-from API.utils.models.genre_models import Cluster
+from utils.models.genre_models import Cluster
 
 def getClusters():
     try:

--- a/API/utils/queries/Cluster/get_clusters_genero.py
+++ b/API/utils/queries/Cluster/get_clusters_genero.py
@@ -1,6 +1,6 @@
 from flask import jsonify
 from sqlalchemy.exc import IntegrityError
-from API.utils.models.genre_models import Cluster
+from utils.models.genre_models import Cluster
 
 def getClusterGenero():
     try:

--- a/API/utils/queries/Genre/crear_genero.py
+++ b/API/utils/queries/Genre/crear_genero.py
@@ -1,9 +1,8 @@
-import uuid
 import traceback
 from utils.database.database import db
 from flask import jsonify
 from sqlalchemy.exc import IntegrityError
-from API.utils.models.genre_models import Genre
+from utils.models.genre_models import Genre
 from sqlalchemy import func, text
 from sqlalchemy import cast
 from sqlalchemy.dialects.postgresql import VARCHAR, INTEGER, BOOLEAN

--- a/API/utils/queries/Genre/get_generos.py
+++ b/API/utils/queries/Genre/get_generos.py
@@ -1,6 +1,6 @@
 from flask import jsonify
 from sqlalchemy.exc import IntegrityError
-from API.utils.models.genre_models import Genre
+from utils.models.genre_models import Genre
 
 def getGeneros():
     try:


### PR DESCRIPTION
Descripción:

Se creó el endpoint completo de crear artista, el cual constía en crear con base en el json que llegaba desde el frontend en primer lugar el artista, seguidamente se guardaba este artista en la base de datos donde el mismo iba a devolver la respuesta del ID creado para el artista. Con este ID creado para el artista se procedia a guardar el array de albumes correspondiente del artista, y por ultimo, se agregaban los miembros del artista en caso de ser una banda.

Cambios:

- api.py
- crear_genero.py
- guardar_miembro.py
- crear_artista.py
